### PR TITLE
return results if there are invalid characters in a directory

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -287,6 +287,7 @@ def listTree(top, files=list(), plexignore=[]):
 		return r
 	except UnicodeDecodeError:
 		Log.Critical("Detected an invalid caracter in the file/directory following this : %s" %(pathname))
+                return r
 	except:
 		Log.Critical("Detected an exception in listTree")
 		bScanStatus = 99


### PR DESCRIPTION
This fixes a problem I had with the scanner. I had some invalid characters in content downloaded from the web which caused the scanner to report an "internal" error in the ui, because the directory scanner returned an implicit ```None```.

The proper fix here would probably be to just ignore the one result and then continue scanning, but that would require a bit of cleanup first.

Since this is my first attempt at fixing a plex plugin: Is there a supported way to drop into a debugger and/or unit-test a plex plugin?